### PR TITLE
Feature/silently run engines

### DIFF
--- a/mikeplus/engines/engine1d.py
+++ b/mikeplus/engines/engine1d.py
@@ -13,13 +13,15 @@ class Engine1D:
         self._result_file = None
 
     def run(self,
-            simMuid=None):
+            simMuid=None, verbose=False):
         """Run MIKE1D simulation
 
         Parameters
         ----------
         simMuid : string, optional
             simulation muid, it will use the current active simulation muid if simMuid is None, by default None.
+        verbose : bool, optional
+            print log file or not, by default False.
 
         Examples
         --------
@@ -43,11 +45,14 @@ class Engine1D:
         file_name = file.split('.')[0]
         log_file = os.path.join(dir, file_name + '_' + simMuid + '.log')
         self._result_file = os.path.join(dir, file_name + '_' + simMuid + '.res1d')
-        print("Simulation is started. Simulation id is '" + simMuid + "'")
+        if verbose:
+            print("Simulation is started. Simulation id is '" + simMuid + "'")
         subprocess.run([mike1d_exec, str(dbOrMuppFile), "-simulationid=" + simMuid, "-logfilename=" + log_file])
-        if self._print_log(log_file) is False:
-            print("Simulation is finished without logFile generated.")
-
+        if verbose:
+            log_file_made = self._print_log(log_file)
+            if log_file_made is False:
+                print("Simulation is finished without logFile generated.")
+                
     @property
     def result_file(self):
         """Get the current simulation result file path

--- a/mikeplus/engines/engine1d.py
+++ b/mikeplus/engines/engine1d.py
@@ -32,8 +32,7 @@ class Engine1D:
         if simMuid is None:
             muid = self._dataTables["msm_Project"].GetMuidsWhere("ActiveProject=1")
             if muid is None and muid.Count == 0:
-                print("Simulation id can't be none.")
-                return
+                raise ValueError("Simulation id can't be none.")
             simMuid = muid[0]
 
         product_info = MikeImport.ActiveProduct()

--- a/mikeplus/engines/epanet.py
+++ b/mikeplus/engines/epanet.py
@@ -35,8 +35,8 @@ class EPANET:
         if simMuid is None:
             simMuid = self._get_active_muid()
             if simMuid is None:
-                print("Simulation id can't be none.")
-                return
+                raise ValueError("Simulation id can't be none.")
+            
         print("Simulation id is " + simMuid)
         data_service = AmeliaDataService()
         data_service.DataTables = self._dataTables

--- a/mikeplus/engines/epanet.py
+++ b/mikeplus/engines/epanet.py
@@ -16,13 +16,15 @@ class EPANET:
         self._result_file = None
 
     def run_engine_epanet(self,
-                          simMuid=None):
+                          simMuid=None, verbose=False):
         """Run EPANET simulation
 
         Parameters
         ----------
         simMuid : string, optional
             simulation muid, it will use the current active simulation muid if simMuid is None, by default None
+        verbose : bool, optional
+            print log file or not, by default False
         
         Examples
         --------
@@ -36,8 +38,9 @@ class EPANET:
             simMuid = self._get_active_muid()
             if simMuid is None:
                 raise ValueError("Simulation id can't be none.")
-            
-        print("Simulation id is " + simMuid)
+        
+        if verbose:
+            print("Simulation id is " + simMuid)
         data_service = AmeliaDataService()
         data_service.DataTables = self._dataTables
         engine_service = AmeliaEngineService()
@@ -51,10 +54,13 @@ class EPANET:
         dir = os.path.dirname(os.path.abspath(self._result_file))
         file_name = os.path.splitext(os.path.split(self._result_file)[1])[0]
         log_file = os.path.join(dir, file_name + '.log')
-        if self._print_log(log_file) is False:
-            if (success is False):
+        if verbose:
+            log_file_made = self._print_log(log_file)
+
+            if not success:
                 print("Simulation failed.")
-            else:
+
+            if not log_file_made:
                 print("Simulation is finished without logFile generated.")
 
     @property

--- a/mikeplus/engines/swmm.py
+++ b/mikeplus/engines/swmm.py
@@ -15,13 +15,15 @@ class SWMM:
         self._result_file = None
 
     def run(self,
-            simMuid=None):
+            simMuid=None, verbose=False):
         """Run SWMM simulation
 
         Parameters
         ----------
         simMuid : string, optional
             simulation muid, it will use the current active simulation muid if simMuid is None, by default None
+        verbose : bool, optional
+            print log file or not, by default False
         
         Examples
         --------
@@ -35,8 +37,9 @@ class SWMM:
             simMuid = self._get_active_muid()
             if simMuid is None:
                 raise ValueError("Simulation id can't be none.")
-            
-        print("Simulation id is " + simMuid)
+        
+        if verbose:            
+            print("Simulation id is " + simMuid)
         data_service = AmeliaDataService()
         data_service.DataTables = self._dataTables
         engine_service = AmeliaEngineService()
@@ -50,10 +53,12 @@ class SWMM:
         dir = os.path.dirname(os.path.abspath(self._result_file))
         file_name = os.path.splitext(os.path.split(self._result_file)[1])[0]
         log_file = os.path.join(dir, file_name + '.log')
-        if self._print_log(log_file) is False:
-            if (success is False):
+        if verbose:
+            if not success:
                 print("Simulation failed.")
-            else:
+                
+            log_file_made = self._print_log(log_file)
+            if log_file_made is False:
                 print("Simulation is finished without logFile generated.")
 
     @property

--- a/mikeplus/engines/swmm.py
+++ b/mikeplus/engines/swmm.py
@@ -34,8 +34,8 @@ class SWMM:
         if simMuid is None:
             simMuid = self._get_active_muid()
             if simMuid is None:
-                print("Simulation id can't be none.")
-                return
+                raise ValueError("Simulation id can't be none.")
+            
         print("Simulation id is " + simMuid)
         data_service = AmeliaDataService()
         data_service.DataTables = self._dataTables


### PR DESCRIPTION
It's nice to run engines without automatically printing all of the log files. This PR adds an option called "verbose" that is set to False by default.