### PR TITLE
Maintenance/fix readme installation instructions

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+    "python.testing.pytestArgs": [
+        "tests"
+    ],
+    "python.testing.unittestEnabled": false,
+    "python.testing.pytestEnabled": true,
+}

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ MIKE+Py is a python interface for MIKE+. Its main features include:
 > * If you encounter any issues or have any feedback, please report them on [GitHub Issues](https://github.com/DHI/mikepluspy/issues).
 
 ## Requirements
-* MIKE+ 2024 update 1 (or greater) with valid license
+* MIKE+ 2024 (or greater) with valid license
 * Python x64 3.8 to 3.12
 * Windows operating system
 
@@ -26,7 +26,8 @@ The version of MIKE+Py you install must match the version of MIKE+ installed on 
 
 | MIKE+ Version | Install command|
 |:--------------|:---------------|
-| MIKE+ 2024 update 1 | `pip install https://github.com/DHI/mikepluspy/archive/refs/tags/v2024.1-latest.zip` |
+| MIKE+ 2024 Update 1 | `pip install https://github.com/DHI/mikepluspy/archive/refs/tags/v2024.1-latest.zip` |
+| MIKE+ 2024 | `pip install https://github.com/DHI/mikepluspy/archive/refs/tags/v2024.0-latest.zip` |
 
 
 ## Examples

--- a/mikeplus/datatableaccess.py
+++ b/mikeplus/datatableaccess.py
@@ -8,6 +8,8 @@ from System.Data import ConnectionState
 from DHI.Amelia.DataModule.Services.DataSource import BaseDataSource
 from DHI.Amelia.DataModule.Services.DataTables import DataTableContainer
 
+from .dotnet import as_dotnet_list
+
 
 class DataTableAccess:
     '''
@@ -96,22 +98,22 @@ class DataTableAccess:
 
         Parameters
         ----------
-        table_name : string
-            table name
-        muid : string
-            muid
-        fields : string array
-            the fields want to get values
+        table_name : str
+            The name of the table to get values from. 
+        muid : str
+            The MUID of the row to get values for.
+        fields : str | List[str]
+            The name of the field(s) to get values for.
 
         Returns
         -------
-        array
-            the specified values get from the table
+        List
+            A list of the requested values in the same order as the fields argument.
         """
-        fieldList = List[str]()
-        for field in fields:
-            fieldList.Add(field)
-        values = self._datatables[table_name].GetFieldValues(muid, fieldList, False)
+        if not isinstance(fields, list):
+            fields = [fields]
+
+        values = self._datatables[table_name].GetFieldValues(muid, as_dotnet_list(fields), False)
         pyValues = []
         i = 0
         if values is not None and len(values) > 0:

--- a/mikeplus/dotnet.py
+++ b/mikeplus/dotnet.py
@@ -1,0 +1,31 @@
+import clr
+
+from System import String
+from System.Collections.Generic import List
+
+def as_dotnet_list(py_list: list, dotnet_type = None):
+    """
+    Convert python list to .NET List.
+
+    Parameters
+    ----------
+    py_list : list
+        The python list to convert.
+    dotnet_type : T, optional
+        The .NET type of the list.
+
+    Returns
+    -------
+    List[T]
+        .NET List<T> object.
+    """
+    if dotnet_type is None:
+        if isinstance(py_list[0], str):
+            dotnet_type = String
+        else:
+            raise NotImplementedError(f"Unsupported type '{type(py_list[0])}'. Please specify with dotnet_type.")
+
+    dotnet_list = List[dotnet_type]()
+    for item in py_list:
+        dotnet_list.Add(item)
+    return dotnet_list

--- a/tests/test_datatable.py
+++ b/tests/test_datatable.py
@@ -1,3 +1,5 @@
+import pytest
+
 import os
 from mikeplus import DataTableAccess
 
@@ -7,6 +9,18 @@ def test_opendatabase():
     data_access = DataTableAccess(file_name)
     data_access.open_database()
     assert data_access.is_database_open() is True
+    data_access.close_database()
+
+# parameterize this test for different table name, MUIDs, fields, and expected values
+@pytest.mark.parametrize("table_name, muid, fields, expected_values", [
+    ("msm_Link", "Link_30", "Length", [4.06]),
+    ])
+def test_get_field_values(table_name, muid, fields, expected_values):
+    file_name = os.path.join("tests", "testdata", "Db", "Sirius", "Sirius.sqlite")
+    data_access = DataTableAccess(file_name)
+    data_access.open_database()
+    values = data_access.get_field_values(table_name, muid, fields)
+    assert values == expected_values
     data_access.close_database()
 
 

--- a/tests/test_datatable.py
+++ b/tests/test_datatable.py
@@ -14,6 +14,7 @@ def test_opendatabase():
 # parameterize this test for different table name, MUIDs, fields, and expected values
 @pytest.mark.parametrize("table_name, muid, fields, expected_values", [
     ("msm_Link", "Link_30", "Length", [4.06]),
+    ('msm_Link', 'Link_30', ['Length', 'Diameter'], [4.06, 1.0]),
     ])
 def test_get_field_values(table_name, muid, fields, expected_values):
     file_name = os.path.join("tests", "testdata", "Db", "Sirius", "Sirius.sqlite")


### PR DESCRIPTION
Minor update to README to bring back installation instructions for MIKE+ 2024 (still relevant.

Also, a fix for #44 