### PR TITLE
Case handling, datetime handling and geometry updates

### DIFF
--- a/mikeplus/dotnet.py
+++ b/mikeplus/dotnet.py
@@ -11,8 +11,6 @@ import clr  # noqa: F401
 import datetime
 from typing import Any, Dict
 
-import pandas as pd
-
 import System
 from System import String, Object, Nullable
 from System.Collections.Generic import List, IList, IDictionary, Dictionary
@@ -56,6 +54,10 @@ class DotNetConverter:
     def to_dotnet_value(value: Any) -> Any:
         """Convert a Python value to its appropriate .NET equivalent for database operations.
 
+        Strings are returned unchanged. DateTime strings must be parsed by
+        the query layer (queries.py) using the destination field's MIKE+ schema type before
+        they reach this converter.
+
         Parameters
         ----------
         value : Any
@@ -64,7 +66,8 @@ class DotNetConverter:
         Returns
         -------
         Any
-            The converted .NET value
+            Converted .NET value, or the original value when no conversion is
+            required.
 
         """
         if value is None:
@@ -78,13 +81,7 @@ class DotNetConverter:
         elif isinstance(value, datetime.datetime):
             return DotNetConverter.to_dotnet_datetime(value)
         elif isinstance(value, str):
-            try:
-                value = pd.to_datetime(value)
-            except ValueError:
-                pass
-            if isinstance(value, datetime.datetime):
-                return DotNetConverter.to_dotnet_datetime(value)
-            return value  # Strings automatically convert
+            return value
         elif isinstance(value, list):
             return DotNetConverter.as_dotnet_list(value)
         # Add other type conversions as needed

--- a/mikeplus/dotnet.py
+++ b/mikeplus/dotnet.py
@@ -16,6 +16,8 @@ from System import String, Object, Nullable
 from System.Collections.Generic import List, IList, IDictionary, Dictionary
 from DHI.Amelia.Infrastructure.Interface.UtilityHelper import GeoAPIHelper
 
+from System.Data import DbType
+import pandas as pd
 
 def get_implementation(net_object: Any, raw: bool = False) -> Any:
     """Get the implementation of a .NET interface object.
@@ -51,17 +53,20 @@ class DotNetConverter:
     """
 
     @staticmethod
-    def to_dotnet_value(value: Any) -> Any:
-        """Convert a Python value to its appropriate .NET equivalent for database operations.
+    def to_dotnet_value(value: Any, db_type: DbType | None = None) -> Any:
+        """Convert a Python value to its appropriate .NET equivalent.
 
-        Strings are returned unchanged. DateTime strings must be parsed by
-        the query layer (queries.py) using the destination field's MIKE+ schema type before
-        they reach this converter.
+        String values are returned unchanged unless ``db_type`` is
+        ``DbType.DateTime``. Strings for DateTime fields are parsed and converted
+        to ``System.DateTime``.
 
         Parameters
         ----------
         value : Any
             The Python value to convert
+
+        db_type : DbType, optional
+            Destination database type. Used to identify DateTime fields.
 
         Returns
         -------
@@ -81,7 +86,11 @@ class DotNetConverter:
         elif isinstance(value, datetime.datetime):
             return DotNetConverter.to_dotnet_datetime(value)
         elif isinstance(value, str):
-            return value
+            if db_type != DbType.DateTime:
+                return value
+            value = pd.to_datetime(value).to_pydatetime()
+            return DotNetConverter.to_dotnet_datetime(value)
+
         elif isinstance(value, list):
             return DotNetConverter.as_dotnet_list(value)
         # Add other type conversions as needed
@@ -116,6 +125,7 @@ class DotNetConverter:
     @staticmethod
     def to_dotnet_dictionary(
         py_dict: Dict[str, Any],
+        column_types: Dict[str, DbType] | None = None
     ) -> Dictionary[String, Object]:
         """Convert a Python dictionary to a .NET Dictionary.
 
@@ -127,6 +137,9 @@ class DotNetConverter:
         py_dict : Dict[str, Any]
             Python dictionary to convert
 
+        column_types : Dict[str, DbType], optional
+            Casefold field names mapped to their destination database types.
+
         Returns
         -------
         Dictionary[String, Object]
@@ -134,12 +147,14 @@ class DotNetConverter:
 
         """
         net_dict = Dictionary[String, Object]()
+        column_types = column_types or {}
 
         if not py_dict:
             return net_dict
 
         for key, value in py_dict.items():
-            net_dict[key] = DotNetConverter.to_dotnet_value(value)
+            db_type = column_types.get(key.casefold())
+            net_dict[key] = DotNetConverter.to_dotnet_value(value, db_type)
 
         return net_dict
 

--- a/mikeplus/queries.py
+++ b/mikeplus/queries.py
@@ -9,12 +9,13 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, Any, Generic, TypeVar, Union
+import pandas as pd
 
 if TYPE_CHECKING:
     from .tables import BaseTable
 
 
-from System.Data import ConnectionState
+from System.Data import ConnectionState, DbType
 
 from .dotnet import DotNetConverter
 from .utils import to_sql
@@ -119,6 +120,46 @@ class BaseQuery(Generic[QueryResultT], ABC):
         wrapped_conditions = [f"({condition})" for condition in self._conditions]
         where_clause = " AND ".join(wrapped_conditions)
         return where_clause
+
+    def _parse_datetime_strings(self, values: dict[str, Any]) -> dict[str, Any]:
+        """Parse strings assigned to schema-declared MIKE+ DateTime fields.
+
+        DateTime fields are identified from the MIKE+ table schema using
+        ``DbType.DateTime``. Field-name matching is case-insensitive. String
+        values assigned to those fields are parsed with ``pandas.to_datetime``;
+        all other fields and value types are left unchanged.
+
+        Parameters
+        ----------
+        values : dict[str, Any]
+            Mapping of MIKE+ field names to values intended for insertion or
+            update.
+
+        Returns
+        -------
+        dict[str, Any]
+            New dictionary containing parsed datetime values where applicable.
+            The input dictionary is not modified.
+
+        Notes
+        -----
+        Parsing errors raised by ``pandas.to_datetime`` are allowed to
+        propagate. Strings in non-DateTime fields are never interpreted as
+        dates.
+
+        """
+        datetime_fields = {
+            column.Field.casefold()
+            for column in self._table._net_table.Columns
+            if column.DbType == DbType.DateTime
+        }
+
+        return {
+            field: pd.to_datetime(value)
+            if isinstance(value, str) and field.casefold() in datetime_fields
+            else value
+            for field, value in values.items()
+        }
 
     def reset(self):
         """Reset the query execution status to allow re-execution.
@@ -318,18 +359,46 @@ class InsertQuery(BaseQuery[str]):
     def _execute_impl(self) -> str:
         """Implement the INSERT query execution.
 
+        Supplied field names are matched case-insensitively to their canonical
+        MIKE+ schema names. Strings assigned to schema-declared DateTime fields
+        are parsed before conversion to .NET values. If no MUID is supplied,
+        MIKE+ generates a unique one. Geometry and user-defined fields are
+        handled separately from ordinary fields.
+
         Returns
         -------
         str
-
             The MUID of the newly inserted row
 
+        Raises
+        ------
+        ValueError
+            If the requested MUID already exists in the active scenario.
 
+        Notes
+        -----
+        Conversion and MIKE+ SDK exceptions are allowed to propagate. This
+        method is called internally by ``BaseQuery.execute``.
 
         """
         net_table = self._table._net_table
 
         values = self._values.copy()
+
+        ud_columns = getattr(self._table, "_user_defined_columns", set()) or set()
+
+        canonical_names = {
+            name.casefold(): name
+            for name in [*self._table.columns, *ud_columns]
+        }
+        canonical_names.update({"muid": "MUID", "geometry": "geometry"})
+
+        values = {
+            canonical_names.get(name.casefold(), name): value
+            for name, value in values.items()
+        }
+
+        values = self._parse_datetime_strings(values)
 
         muid = values.pop("MUID", net_table.CreateUniqueMuid())
 
@@ -344,7 +413,6 @@ class InsertQuery(BaseQuery[str]):
             geometry = DotNetConverter.to_dotnet_geometry(geometry)
 
         # Split values into user-defined and non-user-defined
-        ud_columns = getattr(self._table, "_user_defined_columns", set()) or set()
         non_ud_values = {k: v for k, v in values.items() if k not in ud_columns}
         ud_values = {k: v for k, v in values.items() if k in ud_columns}
 
@@ -396,13 +464,27 @@ class UpdateQuery(BaseQuery[list[str]]):
     def _execute_impl(self) -> list[str]:
         """Implement the UPDATE query execution.
 
+        Schema-declared DateTime strings are parsed before conversion.
+        Ordinary fields are updated with ``SetValuesByCommand`` and geometry
+        is updated separately with ``UpdateGeomByCommand``. User-defined fields
+        are applied individually after those commands.
+
         Returns
         -------
         list of str
-
             List of MUIDs updated
 
+        Raises
+        ------
+        ValueError
+            If no filter is supplied and ``all()`` was not called explicitly.
+        RuntimeError
+            If a requested geometry update does not commit.
 
+        Notes
+        -----
+        Conversion and MIKE+ SDK exceptions are allowed to propagate. This
+        method is called internally by ``BaseQuery.execute``.
 
         """
         # Safety check: if no conditions and all() not called, prevent accidental updates
@@ -415,7 +497,13 @@ class UpdateQuery(BaseQuery[list[str]]):
 
         net_table = self._table._net_table
 
-        values = self._values.copy()
+        values = self._parse_datetime_strings(self._values.copy())
+
+        geometry_key = next(
+            (key for key in values if key.casefold() == "geometry"),
+            None,
+        )
+        geometry = values.pop(geometry_key) if geometry_key is not None else None
 
         # Split values into user-defined and non-user-defined
         ud_columns = getattr(self._table, "_user_defined_columns", set()) or set()
@@ -442,6 +530,18 @@ class UpdateQuery(BaseQuery[list[str]]):
         for muid in muids:
             if net_values_non_ud is not None:
                 net_table.SetValuesByCommand(muid, net_values_non_ud)
+
+            if geometry is not None:
+                result = net_table.UpdateGeomByCommand(
+                    muid,
+                    DotNetConverter.to_dotnet_geometry(geometry),
+                )
+
+                if not result.CmdCommitted:
+                    raise RuntimeError(
+                        result.Msg
+                        or f"Geometry update failed for {self._table.name}, MUID {muid}"
+                    )
 
             for col, val in ud_values.items():
                 net_table.SetValue(muid, col, DotNetConverter.to_dotnet_value(val))

--- a/mikeplus/queries.py
+++ b/mikeplus/queries.py
@@ -9,13 +9,11 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, Any, Generic, TypeVar, Union
-import pandas as pd
 
 if TYPE_CHECKING:
     from .tables import BaseTable
 
-
-from System.Data import ConnectionState, DbType
+from System.Data import ConnectionState
 
 from .dotnet import DotNetConverter
 from .utils import to_sql
@@ -120,46 +118,6 @@ class BaseQuery(Generic[QueryResultT], ABC):
         wrapped_conditions = [f"({condition})" for condition in self._conditions]
         where_clause = " AND ".join(wrapped_conditions)
         return where_clause
-
-    def _parse_datetime_strings(self, values: dict[str, Any]) -> dict[str, Any]:
-        """Parse strings assigned to schema-declared MIKE+ DateTime fields.
-
-        DateTime fields are identified from the MIKE+ table schema using
-        ``DbType.DateTime``. Field-name matching is case-insensitive. String
-        values assigned to those fields are parsed with ``pandas.to_datetime``;
-        all other fields and value types are left unchanged.
-
-        Parameters
-        ----------
-        values : dict[str, Any]
-            Mapping of MIKE+ field names to values intended for insertion or
-            update.
-
-        Returns
-        -------
-        dict[str, Any]
-            New dictionary containing parsed datetime values where applicable.
-            The input dictionary is not modified.
-
-        Notes
-        -----
-        Parsing errors raised by ``pandas.to_datetime`` are allowed to
-        propagate. Strings in non-DateTime fields are never interpreted as
-        dates.
-
-        """
-        datetime_fields = {
-            column.Field.casefold()
-            for column in self._table._net_table.Columns
-            if column.DbType == DbType.DateTime
-        }
-
-        return {
-            field: pd.to_datetime(value)
-            if isinstance(value, str) and field.casefold() in datetime_fields
-            else value
-            for field, value in values.items()
-        }
 
     def reset(self):
         """Reset the query execution status to allow re-execution.
@@ -398,7 +356,10 @@ class InsertQuery(BaseQuery[str]):
             for name, value in values.items()
         }
 
-        values = self._parse_datetime_strings(values)
+        column_types = {
+            column.Field.casefold(): column.DbType
+            for column in net_table.Columns
+        }
 
         muid = values.pop("MUID", net_table.CreateUniqueMuid())
 
@@ -416,7 +377,7 @@ class InsertQuery(BaseQuery[str]):
         non_ud_values = {k: v for k, v in values.items() if k not in ud_columns}
         ud_values = {k: v for k, v in values.items() if k in ud_columns}
 
-        net_values = DotNetConverter.to_dotnet_dictionary(non_ud_values)
+        net_values = DotNetConverter.to_dotnet_dictionary(non_ud_values, column_types)
 
         _, inserted_muid = net_table.InsertByCommand(
             muid,
@@ -426,7 +387,14 @@ class InsertQuery(BaseQuery[str]):
 
         # Set user-defined values after insert (not by command)
         for col, val in ud_values.items():
-            net_table.SetValue(inserted_muid, col, DotNetConverter.to_dotnet_value(val))
+            net_table.SetValue(
+                inserted_muid,
+                col,
+                DotNetConverter.to_dotnet_value(
+                    val,
+                    column_types.get(col.casefold()),
+                ),
+            )
 
         return inserted_muid
 
@@ -497,7 +465,12 @@ class UpdateQuery(BaseQuery[list[str]]):
 
         net_table = self._table._net_table
 
-        values = self._parse_datetime_strings(self._values.copy())
+        column_types = {
+            column.Field.casefold(): column.DbType
+            for column in net_table.Columns
+        }
+
+        values = self._values.copy()
 
         geometry_key = next(
             (key for key in values if key.casefold() == "geometry"),
@@ -511,7 +484,7 @@ class UpdateQuery(BaseQuery[list[str]]):
         ud_values = {k: v for k, v in values.items() if k in ud_columns}
 
         net_values_non_ud = (
-            DotNetConverter.to_dotnet_dictionary(non_ud_values)
+            DotNetConverter.to_dotnet_dictionary(non_ud_values, column_types)
             if non_ud_values
             else None
         )
@@ -544,7 +517,14 @@ class UpdateQuery(BaseQuery[list[str]]):
                     )
 
             for col, val in ud_values.items():
-                net_table.SetValue(muid, col, DotNetConverter.to_dotnet_value(val))
+                net_table.SetValue(
+                    muid,
+                    col,
+                    DotNetConverter.to_dotnet_value(
+                        val,
+                        column_types.get(col.casefold()),
+                    ),
+                )
             updated_muids.append(muid)
 
         return updated_muids

--- a/tests/database/test_queries.py
+++ b/tests/database/test_queries.py
@@ -3,6 +3,8 @@ Tests for the query classes implementing the fluent SQL API.
 """
 from __future__ import annotations
 
+from types import SimpleNamespace
+
 import pytest
 import pandas as pd
 import datetime
@@ -14,6 +16,7 @@ from mikeplus.queries import SelectQuery
 from mikeplus.queries import InsertQuery
 from mikeplus.queries import UpdateQuery
 from mikeplus.queries import DeleteQuery
+from mikeplus.dotnet import DotNetConverter
 from mikeplus.tables.base_table import BaseTable
 
 
@@ -343,6 +346,66 @@ class TestInsertQuery:
 
         assert inserted_muid in table.get_muids()
 
+    def test_insert_accepts_lowercase_field_names(self, table: BaseTable):
+        """Insert lowercase field names into the SQLite integration fixture."""
+        values = {
+            "muid": "case_insensitive_link",
+            "diameter": 12.5,
+            "length": 100.0,
+            "description": "Test lowercase field names",
+        }
+
+        inserted_muid = InsertQuery(table, values).execute()
+
+        expected = {
+            "MUID": values["muid"],
+            "Diameter": values["diameter"],
+            "Length": values["length"],
+            "Description": values["description"],
+        }
+        inserted = table.select(list(expected)).by_muid(inserted_muid).execute()
+
+        assert inserted_muid == values["muid"]
+        assert dict(zip(expected, inserted[inserted_muid])) == expected
+
+    def test_insert_sends_canonical_field_names_to_command(self):
+        """Normalize field names before crossing the MIKE+ command boundary."""
+        captured = {}
+
+        def insert_by_command(muid, geometry, values):
+            captured["muid"] = muid
+            captured["geometry"] = geometry
+            captured["fields"] = set(values.Keys)
+            return None, muid
+
+        net_table = SimpleNamespace(
+            Columns=[],
+            CreateUniqueMuid=lambda: "generated_muid",
+            IsMuidExistInActive=lambda *_: False,
+            InsertByCommand=insert_by_command,
+        )
+        table = SimpleNamespace(
+            _net_table=net_table,
+            _user_defined_columns=set(),
+            columns=["MUID", "Diameter", "Length", "Description"],
+            name="msm_Link",
+        )
+        values = {
+            "muid": "case_insensitive_link",
+            "diameter": 12.5,
+            "length": 100.0,
+            "description": "Test lowercase field names",
+        }
+
+        inserted_muid = InsertQuery(table, values)._execute_impl()
+
+        assert inserted_muid == values["muid"]
+        assert captured == {
+            "muid": values["muid"],
+            "geometry": None,
+            "fields": {"Diameter", "Length", "Description"},
+        }
+
 
 class TestUpdateQuery:
     """Tests for the UpdateQuery class."""
@@ -461,6 +524,95 @@ class TestUpdateQuery:
             f"Expected ComputationBegin to be datetime.datetime, but got {type(retrieved_value)}."
         assert retrieved_value == expected_datetime, \
             f"Expected ComputationBegin datetime {expected_datetime}, but got {retrieved_value}."
+
+    def test_geometry_update_persists(self, sirius_db):
+        """Persist a LINESTRING through the MIKE+ geometry update command."""
+        db = Database(sirius_db)
+        try:
+            table = db.tables.msm_Link
+            muid = "Link_2"
+            geometry = (
+                "LINESTRING (102405.85711669922 108873.84887695312, "
+                "103200 108100, 104049.65692138672 107628.56768798828)"
+            )
+            previous_geometry = table._net_table.GetGeometry(muid).AsText()
+
+            updated_muids = table.update({"geometry": geometry}).by_muid(muid).execute()
+            persisted_geometry = table._net_table.GetGeometry(muid).AsText()
+
+            assert updated_muids == [muid]
+            assert persisted_geometry != previous_geometry
+            assert persisted_geometry == geometry
+        finally:
+            db.close()
+
+    def test_geometry_uses_geometry_command(self, monkeypatch):
+        """Route geometry separately instead of using the ordinary field command."""
+        captured = {}
+        converted_geometry = object()
+
+        def set_values_by_command(muid, values):
+            captured["ordinary"] = (muid, list(values.Keys))
+
+        def update_geom_by_command(muid, geometry):
+            captured["geometry"] = (muid, geometry)
+            return SimpleNamespace(CmdCommitted=True, Msg="")
+
+        net_table = SimpleNamespace(
+            Columns=[],
+            SetValuesByCommand=set_values_by_command,
+            UpdateGeomByCommand=update_geom_by_command,
+        )
+        table = SimpleNamespace(
+            _net_table=net_table,
+            _user_defined_columns=set(),
+            get_muids=lambda: ["Link_2"],
+            name="msm_Link",
+        )
+        monkeypatch.setattr(
+            DotNetConverter,
+            "to_dotnet_geometry",
+            lambda _: converted_geometry,
+        )
+
+        updated_muids = UpdateQuery(
+            table,
+            {"geometry": "LINESTRING (0 0, 1 1)"},
+        ).all()._execute_impl()
+
+        assert updated_muids == ["Link_2"]
+        assert "ordinary" not in captured
+        assert captured["geometry"] == ("Link_2", converted_geometry)
+
+    def test_geometry_command_failure_raises(self, monkeypatch):
+        """Expose a failed geometry commit instead of reporting a successful update."""
+        net_table = SimpleNamespace(
+            Columns=[],
+            SetValuesByCommand=lambda *_: None,
+            UpdateGeomByCommand=lambda *_: SimpleNamespace(
+                CmdCommitted=False,
+                Msg="Geometry command rejected",
+            ),
+        )
+        table = SimpleNamespace(
+            _net_table=net_table,
+            _user_defined_columns=set(),
+            get_muids=lambda: ["Link_2"],
+            name="msm_Link",
+        )
+        monkeypatch.setattr(
+            DotNetConverter,
+            "to_dotnet_geometry",
+            lambda geometry: geometry,
+        )
+
+        query = UpdateQuery(
+            table,
+            {"geometry": "LINESTRING (0 0, 1 1)"},
+        ).all()
+
+        with pytest.raises(RuntimeError, match="Geometry command rejected"):
+            query._execute_impl()
 
 
 class TestDeleteQuery:

--- a/tests/test_dotnet.py
+++ b/tests/test_dotnet.py
@@ -1,0 +1,40 @@
+"""Regression tests for Python-to-.NET value conversion."""
+
+import datetime
+
+import pytest
+from mikeplus.dotnet import DotNetConverter
+import System
+from System.Data import DbType
+
+
+@pytest.mark.parametrize("value", ["760309", "33,34"])
+def test_arbitrary_strings_are_not_inferred_as_datetimes(value):
+    """Keep numeric-looking identifiers and comma-separated text as strings."""
+    converted = DotNetConverter.to_dotnet_value(value)
+
+    assert isinstance(converted, str)
+    assert converted == value
+
+
+def test_dictionary_conversion_respects_schema_column_types():
+    """Convert only strings belonging to schema-declared DateTime fields."""
+    values = {
+        "assetname": "760309",
+        "dem_location": "33,34",
+        "ComputationBegin": "2025-01-01 14:30:00",
+    }
+    column_types = {
+        "assetname": DbType.String,
+        "dem_location": DbType.String,
+        "computationbegin": DbType.DateTime,
+    }
+
+    converted = DotNetConverter.to_dotnet_dictionary(values, column_types)
+
+    assert converted["assetname"] == "760309"
+    assert converted["dem_location"] == "33,34"
+    assert isinstance(converted["ComputationBegin"], System.DateTime)
+    assert DotNetConverter.from_dotnet_datetime(
+        converted["ComputationBegin"]
+    ) == datetime.datetime(2025, 1, 1, 14, 30)


### PR DESCRIPTION
**Problem**

- Numeric-looking strings such as "760309" (assetname) and "33,34" (dem_location) were incorrectly interpreted as dates.
- Insert field names became case-sensitive. Issue: #119.
- Geometry updates were sent through the ordinary field-update command and were not saved correctly.

**Fix**

- dotnet.py: Text values now stay as text unless the destination field is actually a date field.
- queries.py: Insert field names now work regardless of capitalization—for example, both "Description" and "description" are accepted.
- queries.py: Geometries now use the correct MIKE+ geometry update operation.
- queries.py: Apply geometry through UpdateGeomByCommand and raise an explicit error when it does not commit.